### PR TITLE
회원가입 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.mysql:mysql-connector-j'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.mysql:mysql-connector-j'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/project/triplog/TravelTrackerApplication.java
+++ b/src/main/java/com/project/triplog/TravelTrackerApplication.java
@@ -2,7 +2,9 @@ package com.project.triplog;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class TravelTrackerApplication {
 

--- a/src/main/java/com/project/triplog/config/SecurityConfig.java
+++ b/src/main/java/com/project/triplog/config/SecurityConfig.java
@@ -10,17 +10,17 @@ import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 public class SecurityConfig {
-	@Bean
-	public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
-		httpSecurity.csrf(AbstractHttpConfigurer::disable).authorizeHttpRequests(
-			auth -> auth.requestMatchers("/users/join", "/users/validation").permitAll()
-				.anyRequest().authenticated()
-		);
-		return httpSecurity.build();
-	}
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
+        httpSecurity.csrf(AbstractHttpConfigurer::disable).authorizeHttpRequests(
+                auth -> auth.requestMatchers("/users/join", "/users/validation", "/users/email/verification").permitAll()
+                        .anyRequest().authenticated()
+        );
+        return httpSecurity.build();
+    }
 
-	@Bean
-	public PasswordEncoder passwordEncoder() {
-		return new BCryptPasswordEncoder();
-	}
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
 }

--- a/src/main/java/com/project/triplog/config/SecurityConfig.java
+++ b/src/main/java/com/project/triplog/config/SecurityConfig.java
@@ -1,0 +1,26 @@
+package com.project.triplog.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
+		httpSecurity.csrf(AbstractHttpConfigurer::disable).authorizeHttpRequests(
+			auth -> auth.requestMatchers("/users/join", "/users/validation").permitAll()
+				.anyRequest().authenticated()
+		);
+		return httpSecurity.build();
+	}
+
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
+}

--- a/src/main/java/com/project/triplog/controller/UserController.java
+++ b/src/main/java/com/project/triplog/controller/UserController.java
@@ -1,43 +1,57 @@
 package com.project.triplog.controller;
 
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.project.triplog.dto.EmailCheckRequest;
 import com.project.triplog.dto.EmailRequest;
 import com.project.triplog.dto.JoinRequest;
+import com.project.triplog.dto.UsernameCheckRequest;
 import com.project.triplog.service.EmailVerificationService;
 import com.project.triplog.service.UserService;
+
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
 @RequiredArgsConstructor
 public class UserController {
-    private final UserService userService;
-    private final EmailVerificationService emailVerificationService;
+	private final UserService userService;
+	private final EmailVerificationService emailVerificationService;
 
-    @GetMapping("/users/validation")
-    public ResponseEntity<Boolean> checkUsername(@RequestParam String username) {
-        boolean isExists = userService.isExistUsername(username);
-        return ResponseEntity.ok(isExists);
-    }
+	@PostMapping("/users/username/exists")
+	public ResponseEntity<Boolean> checkUsernameExists(@Valid @RequestBody UsernameCheckRequest request) {
+		boolean isExists = userService.isExistUsername(request.getUsername());
+		return ResponseEntity.ok(isExists);
+	}
 
-    @PostMapping("/users/join")
-    public ResponseEntity join(@Valid @RequestBody JoinRequest joinRequest) {
-        userService.join(joinRequest);
-        return ResponseEntity.ok().build();
-    }
+	@PostMapping("/users/email/exists")
+	public ResponseEntity<Boolean> checkEmailExists(@Valid @RequestBody EmailCheckRequest request) {
+		boolean isExists = userService.isExistEmail(request.getEmail());
+		return ResponseEntity.ok(isExists);
+	}
 
-    @PostMapping("/users/email/verification")
-    public ResponseEntity sendVerificationEmail(@RequestBody EmailRequest emailRequest) {
-        emailVerificationService.sendVerificationEmail(emailRequest);
-        return ResponseEntity.ok().build();
-    }
+	@PostMapping("/users/join")
+	public ResponseEntity<Void> join(@Valid @RequestBody JoinRequest joinRequest) {
+		userService.join(joinRequest);
+		return ResponseEntity.ok().build();
+	}
 
-    @GetMapping("/users/email/verification")
-    public ResponseEntity verificationEmail(@RequestParam String email, @RequestParam String token) {
-        emailVerificationService.verifyToken(email, token);
-        return ResponseEntity.ok().build();
-    }
+	@PostMapping("/users/email/verification")
+	public ResponseEntity<Void> sendVerificationEmail(@RequestBody EmailRequest emailRequest) {
+		emailVerificationService.sendVerificationEmail(emailRequest);
+		return ResponseEntity.ok().build();
+	}
+
+	@GetMapping("/users/email/verification")
+	public ResponseEntity<Void> verificationEmail(@RequestParam String email, @RequestParam String token) {
+		emailVerificationService.verifyToken(email, token);
+		return ResponseEntity.ok().build();
+	}
 }

--- a/src/main/java/com/project/triplog/controller/UserController.java
+++ b/src/main/java/com/project/triplog/controller/UserController.java
@@ -1,0 +1,23 @@
+package com.project.triplog.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.project.triplog.service.UserService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class UserController {
+	private final UserService userService;
+
+	@GetMapping("/users/validation")
+	public ResponseEntity<Boolean> checkUsername(@RequestParam String username) {
+		boolean isExists = userService.isExistUsername(username);
+		return ResponseEntity.ok(isExists);
+	}
+
+}

--- a/src/main/java/com/project/triplog/controller/UserController.java
+++ b/src/main/java/com/project/triplog/controller/UserController.java
@@ -1,14 +1,13 @@
 package com.project.triplog.controller;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.project.triplog.dto.EmailCheckRequest;
 import com.project.triplog.dto.EmailRequest;
+import com.project.triplog.dto.EmailVerificationRequest;
 import com.project.triplog.dto.JoinRequest;
 import com.project.triplog.dto.UsernameCheckRequest;
 import com.project.triplog.service.EmailVerificationService;
@@ -43,15 +42,15 @@ public class UserController {
 		return ResponseEntity.ok().build();
 	}
 
-	@PostMapping("/users/email/verification")
-	public ResponseEntity<Void> sendVerificationEmail(@RequestBody EmailRequest emailRequest) {
+	@PostMapping("/users/email/request-verification")
+	public ResponseEntity<Void> requestEmailVerification(@RequestBody EmailRequest emailRequest) {
 		emailVerificationService.sendVerificationEmail(emailRequest);
 		return ResponseEntity.ok().build();
 	}
 
-	@GetMapping("/users/email/verification")
-	public ResponseEntity<Void> verificationEmail(@RequestParam String email, @RequestParam String token) {
-		emailVerificationService.verifyToken(email, token);
+	@PostMapping("/users/email/verification")
+	public ResponseEntity<Void> verifyEmail(@Valid @RequestBody EmailVerificationRequest request) {
+		emailVerificationService.verifyToken(request.getEmail(), request.getToken());
 		return ResponseEntity.ok().build();
 	}
 }

--- a/src/main/java/com/project/triplog/controller/UserController.java
+++ b/src/main/java/com/project/triplog/controller/UserController.java
@@ -2,11 +2,15 @@ package com.project.triplog.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.project.triplog.dto.JoinRequest;
 import com.project.triplog.service.UserService;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -20,4 +24,9 @@ public class UserController {
 		return ResponseEntity.ok(isExists);
 	}
 
+	@PostMapping("/users/join")
+	public ResponseEntity join(@Valid @RequestBody JoinRequest joinRequest) {
+		userService.join(joinRequest);
+		return ResponseEntity.ok().build();
+	}
 }

--- a/src/main/java/com/project/triplog/controller/UserController.java
+++ b/src/main/java/com/project/triplog/controller/UserController.java
@@ -1,32 +1,43 @@
 package com.project.triplog.controller;
 
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
-
+import com.project.triplog.dto.EmailRequest;
 import com.project.triplog.dto.JoinRequest;
+import com.project.triplog.service.EmailVerificationService;
 import com.project.triplog.service.UserService;
-
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 public class UserController {
-	private final UserService userService;
+    private final UserService userService;
+    private final EmailVerificationService emailVerificationService;
 
-	@GetMapping("/users/validation")
-	public ResponseEntity<Boolean> checkUsername(@RequestParam String username) {
-		boolean isExists = userService.isExistUsername(username);
-		return ResponseEntity.ok(isExists);
-	}
+    @GetMapping("/users/validation")
+    public ResponseEntity<Boolean> checkUsername(@RequestParam String username) {
+        boolean isExists = userService.isExistUsername(username);
+        return ResponseEntity.ok(isExists);
+    }
 
-	@PostMapping("/users/join")
-	public ResponseEntity join(@Valid @RequestBody JoinRequest joinRequest) {
-		userService.join(joinRequest);
-		return ResponseEntity.ok().build();
-	}
+    @PostMapping("/users/join")
+    public ResponseEntity join(@Valid @RequestBody JoinRequest joinRequest) {
+        userService.join(joinRequest);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/users/email/verification")
+    public ResponseEntity sendVerificationEmail(@RequestBody EmailRequest emailRequest) {
+        emailVerificationService.sendVerificationEmail(emailRequest);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/users/email/verification")
+    public ResponseEntity verificationEmail(@RequestParam String email, @RequestParam String token) {
+        emailVerificationService.verifyToken(email, token);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/project/triplog/controller/UserController.java
+++ b/src/main/java/com/project/triplog/controller/UserController.java
@@ -9,7 +9,7 @@ import com.project.triplog.dto.EmailCheckRequest;
 import com.project.triplog.dto.EmailRequest;
 import com.project.triplog.dto.EmailVerificationRequest;
 import com.project.triplog.dto.JoinRequest;
-import com.project.triplog.dto.UsernameCheckRequest;
+import com.project.triplog.dto.UserIdCheckRequest;
 import com.project.triplog.service.EmailVerificationService;
 import com.project.triplog.service.UserService;
 
@@ -24,9 +24,9 @@ public class UserController {
 	private final UserService userService;
 	private final EmailVerificationService emailVerificationService;
 
-	@PostMapping("/users/username/exists")
-	public ResponseEntity<Boolean> checkUsernameExists(@Valid @RequestBody UsernameCheckRequest request) {
-		boolean isExists = userService.isExistUsername(request.getUsername());
+	@PostMapping("/users/userid/exists")
+	public ResponseEntity<Boolean> checkUserIdExists(@Valid @RequestBody UserIdCheckRequest request) {
+		boolean isExists = userService.isExistUserId(request.getUserId());
 		return ResponseEntity.ok(isExists);
 	}
 

--- a/src/main/java/com/project/triplog/domain/EmailVerification.java
+++ b/src/main/java/com/project/triplog/domain/EmailVerification.java
@@ -1,0 +1,37 @@
+package com.project.triplog.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class EmailVerification {
+    @Id
+    private String email;
+    private String token;
+    private boolean verified;
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    public static EmailVerification of(String email, String token) {
+        EmailVerification emailVerification = new EmailVerification();
+        emailVerification.email = email;
+        emailVerification.token = token;
+        emailVerification.verified = false;
+        return emailVerification;
+    }
+
+    public void completeVerification() {
+        this.verified = true;
+    }
+}

--- a/src/main/java/com/project/triplog/domain/User.java
+++ b/src/main/java/com/project/triplog/domain/User.java
@@ -24,7 +24,7 @@ public class User {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
-	private String username;
+	private String userId;
 	private String name;
 	private String email;
 	private String password;
@@ -33,7 +33,7 @@ public class User {
 
 	public static User from(JoinRequest joinRequest, String newPassword) {
 		User user = new User();
-		user.username = joinRequest.getUsername();
+		user.userId = joinRequest.getUserId();
 		user.name = joinRequest.getName();
 		user.email = joinRequest.getEmail();
 		user.password = newPassword;

--- a/src/main/java/com/project/triplog/domain/User.java
+++ b/src/main/java/com/project/triplog/domain/User.java
@@ -1,0 +1,42 @@
+package com.project.triplog.domain;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import com.project.triplog.dto.JoinRequest;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	private String username;
+	private String name;
+	private String email;
+	private String password;
+	@CreatedDate
+	private LocalDateTime createdAt;
+
+	public static User from(JoinRequest joinRequest) {
+		User user = new User();
+		user.username = joinRequest.getUsername();
+		user.name = joinRequest.getName();
+		user.email = joinRequest.getEmail();
+		user.password = joinRequest.getPassword();
+		return user;
+	}
+}

--- a/src/main/java/com/project/triplog/domain/User.java
+++ b/src/main/java/com/project/triplog/domain/User.java
@@ -31,12 +31,12 @@ public class User {
 	@CreatedDate
 	private LocalDateTime createdAt;
 
-	public static User from(JoinRequest joinRequest) {
+	public static User from(JoinRequest joinRequest, String newPassword) {
 		User user = new User();
 		user.username = joinRequest.getUsername();
 		user.name = joinRequest.getName();
 		user.email = joinRequest.getEmail();
-		user.password = joinRequest.getPassword();
+		user.password = newPassword;
 		return user;
 	}
 }

--- a/src/main/java/com/project/triplog/dto/EmailCheckRequest.java
+++ b/src/main/java/com/project/triplog/dto/EmailCheckRequest.java
@@ -1,0 +1,15 @@
+package com.project.triplog.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class EmailCheckRequest {
+
+	@NotBlank(message = "이메일은 필수입니다.")
+	@Email(message = "유효한 이메일 형식이 아닙니다.")
+	private String email;
+}

--- a/src/main/java/com/project/triplog/dto/EmailRequest.java
+++ b/src/main/java/com/project/triplog/dto/EmailRequest.java
@@ -1,0 +1,14 @@
+package com.project.triplog.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class EmailRequest {
+    @Email(message = "유효한 이메일 형식이 아닙니다.")
+    @NotBlank(message = "이메일은 필수 입력 항목입니다.")
+    private final String email;
+}

--- a/src/main/java/com/project/triplog/dto/EmailVerificationRequest.java
+++ b/src/main/java/com/project/triplog/dto/EmailVerificationRequest.java
@@ -1,0 +1,18 @@
+package com.project.triplog.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class EmailVerificationRequest {
+
+	@NotBlank(message = "이메일은 필수입니다.")
+	@Email(message = "유효한 이메일 형식이 아닙니다.")
+	private String email;
+
+	@NotBlank(message = "토큰은 필수입니다.")
+	private String token;
+}

--- a/src/main/java/com/project/triplog/dto/JoinRequest.java
+++ b/src/main/java/com/project/triplog/dto/JoinRequest.java
@@ -9,8 +9,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public class JoinRequest {
-	@NotBlank(message = "사용자 이름은 필수 입력 항목입니다.")
-	private final String username;
+	@NotBlank(message = "사용자 아이디는 필수 입력 항목입니다.")
+	private final String userId;
 	@NotBlank(message = "이름은 필수 입력 항목입니다.")
 	private final String name;
 	@Email(message = "유효한 이메일 형식이 아닙니다.")

--- a/src/main/java/com/project/triplog/dto/JoinRequest.java
+++ b/src/main/java/com/project/triplog/dto/JoinRequest.java
@@ -1,0 +1,22 @@
+package com.project.triplog.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class JoinRequest {
+	@NotBlank(message = "사용자 이름은 필수 입력 항목입니다.")
+	private final String username;
+	@NotBlank(message = "이름은 필수 입력 항목입니다.")
+	private final String name;
+	@Email(message = "유효한 이메일 형식이 아닙니다.")
+	@NotBlank(message = "이메일은 필수 입력 항목입니다.")
+	private final String email;
+	@NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
+	@Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하로 입력해야 합니다.")
+	private final String password;
+}

--- a/src/main/java/com/project/triplog/dto/UserIdCheckRequest.java
+++ b/src/main/java/com/project/triplog/dto/UserIdCheckRequest.java
@@ -1,0 +1,13 @@
+package com.project.triplog.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UserIdCheckRequest {
+
+	@NotBlank(message = "사용자 아이디는 필수입니다.")
+	private String userId;
+}

--- a/src/main/java/com/project/triplog/dto/UsernameCheckRequest.java
+++ b/src/main/java/com/project/triplog/dto/UsernameCheckRequest.java
@@ -1,0 +1,13 @@
+package com.project.triplog.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UsernameCheckRequest {
+
+	@NotBlank(message = "사용자명은 필수입니다.")
+	private String username;
+}

--- a/src/main/java/com/project/triplog/exception/DuplicationException.java
+++ b/src/main/java/com/project/triplog/exception/DuplicationException.java
@@ -1,0 +1,12 @@
+package com.project.triplog.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.project.triplog.global.exception.BaseException;
+import com.project.triplog.global.exception.ErrorCode;
+
+public class DuplicationException extends BaseException {
+	public DuplicationException(String message) {
+		super(HttpStatus.CONFLICT, ErrorCode.DUPLICATION.getCode(), message);
+	}
+}

--- a/src/main/java/com/project/triplog/exception/EmailSendException.java
+++ b/src/main/java/com/project/triplog/exception/EmailSendException.java
@@ -1,0 +1,12 @@
+package com.project.triplog.exception;
+
+import com.project.triplog.global.exception.BaseException;
+import com.project.triplog.global.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class EmailSendException extends BaseException {
+    public EmailSendException() {
+        super(HttpStatus.BAD_GATEWAY, ErrorCode.EMAIL_NOT_VERIFIED.getCode(),
+                ErrorCode.EMAIL_NOT_VERIFIED.getMessage());
+    }
+}

--- a/src/main/java/com/project/triplog/exception/EmailVerifiedException.java
+++ b/src/main/java/com/project/triplog/exception/EmailVerifiedException.java
@@ -1,0 +1,13 @@
+package com.project.triplog.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.project.triplog.global.exception.BaseException;
+import com.project.triplog.global.exception.ErrorCode;
+
+public class EmailVerifiedException extends BaseException {
+	public EmailVerifiedException() {
+		super(HttpStatus.BAD_REQUEST, ErrorCode.EMAIL_NOT_VERIFIED.getCode(),
+			ErrorCode.EMAIL_NOT_VERIFIED.getMessage());
+	}
+}

--- a/src/main/java/com/project/triplog/global/exception/ErrorCode.java
+++ b/src/main/java/com/project/triplog/global/exception/ErrorCode.java
@@ -4,17 +4,20 @@ import lombok.Getter;
 
 @Getter
 public enum ErrorCode {
-	UNKNOWN_ERROR("UNKNOWN_ERROR", "알 수 없는 오류가 발생하였습니다."),
-	INVALID_VALUE("INVALID_VALUE", "유효하지 않은 값이 입력되었습니다."),
-	NOT_FOUND("NOT_FOUND", "요청한 리소스를 찾을 수 없습니다."),
-	DUPLICATION("DUPLICATION", "이미 존재하는 값입니다."),
-	PARAMETER_MISSING("PARAMETER_MISSING", "필수 요청 파라미터가 누락되었습니다.");
+    UNKNOWN_ERROR("UNKNOWN_ERROR", "알 수 없는 오류가 발생하였습니다."),
+    INVALID_VALUE("INVALID_VALUE", "유효하지 않은 값이 입력되었습니다."),
+    NOT_FOUND("NOT_FOUND", "요청한 리소스를 찾을 수 없습니다."),
+    DUPLICATION("DUPLICATION", "이미 존재하는 값입니다."),
+    EMAIL_NOT_VERIFIED("EMAIL_NOT_VERIFIED", "이메일 인증이 완료되지 않았습니다."),
+    PARAMETER_MISSING("PARAMETER_MISSING", "필수 요청 파라미터가 누락되었습니다."),
+    EMAIL_SEND_FAILURE("EMAIL_SEND_FAILURE", "이메일 전송에 실패하였습니다."),
+    ;
 
-	private final String code;
-	private final String message;
+    private final String code;
+    private final String message;
 
-	ErrorCode(String code, String message) {
-		this.code = code;
-		this.message = message;
-	}
+    ErrorCode(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
 }

--- a/src/main/java/com/project/triplog/global/exception/ErrorCode.java
+++ b/src/main/java/com/project/triplog/global/exception/ErrorCode.java
@@ -6,7 +6,9 @@ import lombok.Getter;
 public enum ErrorCode {
 	UNKNOWN_ERROR("UNKNOWN_ERROR", "알 수 없는 오류가 발생하였습니다."),
 	INVALID_VALUE("INVALID_VALUE", "유효하지 않은 값이 입력되었습니다."),
-	NOT_FOUND("NOT_FOUND", "요청한 리소스를 찾을 수 없습니다.");;
+	NOT_FOUND("NOT_FOUND", "요청한 리소스를 찾을 수 없습니다."),
+	DUPLICATION("DUPLICATION", "이미 존재하는 값입니다."),
+	PARAMETER_MISSING("PARAMETER_MISSING", "필수 요청 파라미터가 누락되었습니다.");
 
 	private final String code;
 	private final String message;

--- a/src/main/java/com/project/triplog/global/exception/ErrorResponse.java
+++ b/src/main/java/com/project/triplog/global/exception/ErrorResponse.java
@@ -7,8 +7,10 @@ import org.springframework.http.HttpStatus;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+@Getter
 @RequiredArgsConstructor
 public class ErrorResponse {
 	private final HttpStatus status;

--- a/src/main/java/com/project/triplog/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/project/triplog/global/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.NoHandlerFoundException;
@@ -37,6 +38,17 @@ public class GlobalExceptionHandler {
 
 		ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.BAD_REQUEST, ErrorCode.INVALID_VALUE.getCode(),
 			ErrorCode.INVALID_VALUE.getMessage(), fieldErrors);
+
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+	}
+
+	@ExceptionHandler(MissingServletRequestParameterException.class)
+	public ResponseEntity<ErrorResponse> handleMissingServletRequestParameterException(
+		MissingServletRequestParameterException exception) {
+
+		ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.BAD_REQUEST,
+			ErrorCode.PARAMETER_MISSING.getCode(),
+			ErrorCode.PARAMETER_MISSING.getMessage());
 
 		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
 	}

--- a/src/main/java/com/project/triplog/repository/EmailVerificationRepository.java
+++ b/src/main/java/com/project/triplog/repository/EmailVerificationRepository.java
@@ -1,0 +1,14 @@
+package com.project.triplog.repository;
+
+import com.project.triplog.domain.EmailVerification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface EmailVerificationRepository extends JpaRepository<EmailVerification, String> {
+    Optional<EmailVerification> findByEmail(String email);
+
+    void deleteByEmail(String email);
+}

--- a/src/main/java/com/project/triplog/repository/UserRepository.java
+++ b/src/main/java/com/project/triplog/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.project.triplog.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.project.triplog.domain.User;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+	boolean existsByUsername(String username);
+}

--- a/src/main/java/com/project/triplog/repository/UserRepository.java
+++ b/src/main/java/com/project/triplog/repository/UserRepository.java
@@ -8,4 +8,6 @@ import com.project.triplog.domain.User;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 	boolean existsByUsername(String username);
+
+	boolean existsByEmail(String email);
 }

--- a/src/main/java/com/project/triplog/repository/UserRepository.java
+++ b/src/main/java/com/project/triplog/repository/UserRepository.java
@@ -7,7 +7,7 @@ import com.project.triplog.domain.User;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-	boolean existsByUsername(String username);
+	boolean existsByUserId(String userId);
 
 	boolean existsByEmail(String email);
 }

--- a/src/main/java/com/project/triplog/service/EmailVerificationService.java
+++ b/src/main/java/com/project/triplog/service/EmailVerificationService.java
@@ -48,7 +48,7 @@ public class EmailVerificationService {
 
 	public void sendVerificationEmail(EmailRequest emailRequest) {
 		String token = generateToken(emailRequest.getEmail());
-		String verificationUrl = "http://localhost:8080/api/v1/members/email-verification?email="
+		String verificationUrl = "http://localhost:8080/users/email/verification?email="
 			+ URLEncoder.encode(emailRequest.getEmail(), StandardCharsets.UTF_8)
 			+ "&token=" + token;
 		String subject = "회원가입 : 이메일 인증";

--- a/src/main/java/com/project/triplog/service/EmailVerificationService.java
+++ b/src/main/java/com/project/triplog/service/EmailVerificationService.java
@@ -1,0 +1,68 @@
+package com.project.triplog.service;
+
+import com.project.triplog.domain.EmailVerification;
+import com.project.triplog.dto.EmailRequest;
+import com.project.triplog.exception.EmailSendException;
+import com.project.triplog.exception.EmailVerifiedException;
+import com.project.triplog.repository.EmailVerificationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmailVerificationService {
+    private final EmailVerificationRepository emailVerificationRepository;
+    private final JavaMailSender mailSender;
+
+    public String generateToken(String email) {
+        String token = UUID.randomUUID().toString();
+        System.out.println("Generated token for email " + email + ": " + token);
+        EmailVerification emailVerification = EmailVerification.of(email, token);
+        emailVerificationRepository.save(emailVerification);
+        return token;
+    }
+
+    public boolean verifyToken(String email, String token) {
+        Optional<EmailVerification> emailVerificationOpt = emailVerificationRepository.findByEmail(email);
+        if (emailVerificationOpt.isEmpty()) {
+            throw new EmailVerifiedException();
+        }
+
+        EmailVerification emailVerification = emailVerificationOpt.get();
+        if (!emailVerification.getToken().equals(token)) {
+            throw new EmailVerifiedException();
+        }
+        emailVerification.completeVerification();
+        return true;
+    }
+
+    public void sendVerificationEmail(EmailRequest emailRequest) {
+        String token = generateToken(emailRequest.getEmail());
+        String verificationUrl = "http://localhost:8080/api/v1/members/email-verification?email="
+                + URLEncoder.encode(emailRequest.getEmail(), StandardCharsets.UTF_8)
+                + "&token=" + token;
+        String subject = "회원가입 : 이메일 인증";
+        String body = "아래 링크를 클릭해 이메일 인증을 완료해 주세요:\n" + verificationUrl;
+
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(emailRequest.getEmail());
+        message.setSubject(subject);
+        message.setText(body);
+
+        try {
+            mailSender.send(message);
+        } catch (Exception e) {
+            log.error("Failed to send verification email to {}", emailRequest.getEmail());
+            throw new EmailSendException();
+        }
+    }
+}

--- a/src/main/java/com/project/triplog/service/EmailVerificationService.java
+++ b/src/main/java/com/project/triplog/service/EmailVerificationService.java
@@ -1,80 +1,81 @@
 package com.project.triplog.service;
 
-import com.project.triplog.domain.EmailVerification;
-import com.project.triplog.dto.EmailRequest;
-import com.project.triplog.exception.EmailSendException;
-import com.project.triplog.exception.EmailVerifiedException;
-import com.project.triplog.repository.EmailVerificationRepository;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.mail.SimpleMailMessage;
-import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.stereotype.Service;
-
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import com.project.triplog.domain.EmailVerification;
+import com.project.triplog.dto.EmailRequest;
+import com.project.triplog.exception.EmailSendException;
+import com.project.triplog.exception.EmailVerifiedException;
+import com.project.triplog.repository.EmailVerificationRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class EmailVerificationService {
-    private final EmailVerificationRepository emailVerificationRepository;
-    private final JavaMailSender mailSender;
+	private final EmailVerificationRepository emailVerificationRepository;
+	private final JavaMailSender mailSender;
 
-    public String generateToken(String email) {
-        String token = UUID.randomUUID().toString();
-        System.out.println("Generated token for email " + email + ": " + token);
-        EmailVerification emailVerification = EmailVerification.of(email, token);
-        emailVerificationRepository.save(emailVerification);
-        return token;
-    }
+	public String generateToken(String email) {
+		String token = UUID.randomUUID().toString();
+		EmailVerification emailVerification = EmailVerification.of(email, token);
+		emailVerificationRepository.save(emailVerification);
+		return token;
+	}
 
-    public boolean verifyToken(String email, String token) {
-        Optional<EmailVerification> emailVerificationOpt = emailVerificationRepository.findByEmail(email);
-        if (emailVerificationOpt.isEmpty()) {
-            throw new EmailVerifiedException();
-        }
+	public boolean verifyToken(String email, String token) {
+		Optional<EmailVerification> emailVerificationOpt = emailVerificationRepository.findByEmail(email);
+		if (emailVerificationOpt.isEmpty()) {
+			throw new EmailVerifiedException();
+		}
 
-        EmailVerification emailVerification = emailVerificationOpt.get();
-        if (!emailVerification.getToken().equals(token)) {
-            throw new EmailVerifiedException();
-        }
-        emailVerification.completeVerification();
-        return true;
-    }
+		EmailVerification emailVerification = emailVerificationOpt.get();
+		if (!emailVerification.getToken().equals(token)) {
+			throw new EmailVerifiedException();
+		}
+		emailVerification.completeVerification();
+		return true;
+	}
 
-    public void sendVerificationEmail(EmailRequest emailRequest) {
-        String token = generateToken(emailRequest.getEmail());
-        String verificationUrl = "http://localhost:8080/api/v1/members/email-verification?email="
-                + URLEncoder.encode(emailRequest.getEmail(), StandardCharsets.UTF_8)
-                + "&token=" + token;
-        String subject = "회원가입 : 이메일 인증";
-        String body = "아래 링크를 클릭해 이메일 인증을 완료해 주세요:\n" + verificationUrl;
+	public void sendVerificationEmail(EmailRequest emailRequest) {
+		String token = generateToken(emailRequest.getEmail());
+		String verificationUrl = "http://localhost:8080/api/v1/members/email-verification?email="
+			+ URLEncoder.encode(emailRequest.getEmail(), StandardCharsets.UTF_8)
+			+ "&token=" + token;
+		String subject = "회원가입 : 이메일 인증";
+		String body = "아래 링크를 클릭해 이메일 인증을 완료해 주세요:\n" + verificationUrl;
 
-        SimpleMailMessage message = new SimpleMailMessage();
-        message.setTo(emailRequest.getEmail());
-        message.setSubject(subject);
-        message.setText(body);
+		SimpleMailMessage message = new SimpleMailMessage();
+		message.setTo(emailRequest.getEmail());
+		message.setSubject(subject);
+		message.setText(body);
 
-        try {
-            mailSender.send(message);
-        } catch (Exception e) {
-            log.error("Failed to send verification email to {}", emailRequest.getEmail());
-            throw new EmailSendException();
-        }
-    }
+		try {
+			mailSender.send(message);
+		} catch (Exception e) {
+			log.error("Failed to send verification email to {}", emailRequest.getEmail());
+			throw new EmailSendException();
+		}
+	}
 
-    public void checkVerified(String email) {
-        EmailVerification emailVerification = emailVerificationRepository.findByEmail(email)
-                .orElseThrow(() -> new EmailVerifiedException());
-        if (!emailVerification.isVerified()) {
-            throw new EmailVerifiedException();
-        }
-    }
+	public void checkVerified(String email) {
+		EmailVerification emailVerification = emailVerificationRepository.findByEmail(email)
+			.orElseThrow(() -> new EmailVerifiedException());
+		if (!emailVerification.isVerified()) {
+			throw new EmailVerifiedException();
+		}
+	}
 
-    public void deleteVerification(String email) {
-        emailVerificationRepository.deleteByEmail(email);
-    }
+	public void deleteVerification(String email) {
+		emailVerificationRepository.deleteByEmail(email);
+	}
 }

--- a/src/main/java/com/project/triplog/service/EmailVerificationService.java
+++ b/src/main/java/com/project/triplog/service/EmailVerificationService.java
@@ -65,4 +65,16 @@ public class EmailVerificationService {
             throw new EmailSendException();
         }
     }
+
+    public void checkVerified(String email) {
+        EmailVerification emailVerification = emailVerificationRepository.findByEmail(email)
+                .orElseThrow(() -> new EmailVerifiedException());
+        if (!emailVerification.isVerified()) {
+            throw new EmailVerifiedException();
+        }
+    }
+
+    public void deleteVerification(String email) {
+        emailVerificationRepository.deleteByEmail(email);
+    }
 }

--- a/src/main/java/com/project/triplog/service/UserService.java
+++ b/src/main/java/com/project/triplog/service/UserService.java
@@ -1,5 +1,6 @@
 package com.project.triplog.service;
 
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import com.project.triplog.domain.User;
@@ -13,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class UserService {
 	private final UserRepository userRepository;
+	private final PasswordEncoder passwordEncoder;
 
 	public boolean isExistUsername(String username) {
 		return userRepository.existsByUsername(username);
@@ -25,8 +27,14 @@ public class UserService {
 		if (isExistEmail(joinRequest.getEmail())) {
 			throw new DuplicationException("이미 존재하는 이메일입니다.");
 		}
-		User user = User.from(joinRequest);
+
+		String newPassword = encodingPassword(joinRequest.getPassword());
+		User user = User.from(joinRequest, newPassword);
 		userRepository.save(user);
+	}
+
+	private String encodingPassword(String password) {
+		return passwordEncoder.encode(password);
 	}
 
 	private boolean isExistEmail(String email) {

--- a/src/main/java/com/project/triplog/service/UserService.java
+++ b/src/main/java/com/project/triplog/service/UserService.java
@@ -21,6 +21,10 @@ public class UserService {
 		return userRepository.existsByUsername(username);
 	}
 
+	public boolean isExistEmail(String email) {
+		return userRepository.existsByEmail(email);
+	}
+
 	public void join(JoinRequest joinRequest) {
 		emailVerificationService.checkVerified(joinRequest.getEmail());
 		if (isExistUsername(joinRequest.getUsername())) {
@@ -39,9 +43,5 @@ public class UserService {
 
 	private String encodingPassword(String password) {
 		return passwordEncoder.encode(password);
-	}
-
-	private boolean isExistEmail(String email) {
-		return userRepository.existsByEmail(email);
 	}
 }

--- a/src/main/java/com/project/triplog/service/UserService.java
+++ b/src/main/java/com/project/triplog/service/UserService.java
@@ -17,8 +17,8 @@ public class UserService {
 	private final PasswordEncoder passwordEncoder;
 	private final EmailVerificationService emailVerificationService;
 
-	public boolean isExistUsername(String username) {
-		return userRepository.existsByUsername(username);
+	public boolean isExistUserId(String userId) {
+		return userRepository.existsByUserId(userId);
 	}
 
 	public boolean isExistEmail(String email) {
@@ -27,8 +27,8 @@ public class UserService {
 
 	public void join(JoinRequest joinRequest) {
 		emailVerificationService.checkVerified(joinRequest.getEmail());
-		if (isExistUsername(joinRequest.getUsername())) {
-			throw new DuplicationException("이미 존재하는 사용자 이름입니다.");
+		if (isExistUserId(joinRequest.getUserId())) {
+			throw new DuplicationException("이미 존재하는 사용자 아이디입니다.");
 		}
 		if (isExistEmail(joinRequest.getEmail())) {
 			throw new DuplicationException("이미 존재하는 이메일입니다.");

--- a/src/main/java/com/project/triplog/service/UserService.java
+++ b/src/main/java/com/project/triplog/service/UserService.java
@@ -1,0 +1,17 @@
+package com.project.triplog.service;
+
+import org.springframework.stereotype.Service;
+
+import com.project.triplog.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+	private final UserRepository userRepository;
+
+	public boolean isExistUsername(String username) {
+		return userRepository.existsByUsername(username);
+	}
+}

--- a/src/main/java/com/project/triplog/service/UserService.java
+++ b/src/main/java/com/project/triplog/service/UserService.java
@@ -15,12 +15,14 @@ import lombok.RequiredArgsConstructor;
 public class UserService {
 	private final UserRepository userRepository;
 	private final PasswordEncoder passwordEncoder;
+	private final EmailVerificationService emailVerificationService;
 
 	public boolean isExistUsername(String username) {
 		return userRepository.existsByUsername(username);
 	}
 
 	public void join(JoinRequest joinRequest) {
+		emailVerificationService.checkVerified(joinRequest.getEmail());
 		if (isExistUsername(joinRequest.getUsername())) {
 			throw new DuplicationException("이미 존재하는 사용자 이름입니다.");
 		}
@@ -31,6 +33,8 @@ public class UserService {
 		String newPassword = encodingPassword(joinRequest.getPassword());
 		User user = User.from(joinRequest, newPassword);
 		userRepository.save(user);
+
+		emailVerificationService.deleteVerification(joinRequest.getEmail());
 	}
 
 	private String encodingPassword(String password) {

--- a/src/main/java/com/project/triplog/service/UserService.java
+++ b/src/main/java/com/project/triplog/service/UserService.java
@@ -2,6 +2,9 @@ package com.project.triplog.service;
 
 import org.springframework.stereotype.Service;
 
+import com.project.triplog.domain.User;
+import com.project.triplog.dto.JoinRequest;
+import com.project.triplog.exception.DuplicationException;
 import com.project.triplog.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -13,5 +16,20 @@ public class UserService {
 
 	public boolean isExistUsername(String username) {
 		return userRepository.existsByUsername(username);
+	}
+
+	public void join(JoinRequest joinRequest) {
+		if (isExistUsername(joinRequest.getUsername())) {
+			throw new DuplicationException("이미 존재하는 사용자 이름입니다.");
+		}
+		if (isExistEmail(joinRequest.getEmail())) {
+			throw new DuplicationException("이미 존재하는 이메일입니다.");
+		}
+		User user = User.from(joinRequest);
+		userRepository.save(user);
+	}
+
+	private boolean isExistEmail(String email) {
+		return userRepository.existsByEmail(email);
 	}
 }

--- a/src/main/resources/application-mail.yml
+++ b/src/main/resources/application-mail.yml
@@ -1,0 +1,12 @@
+spring:
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: triplog.dev@gmail.com
+    password:
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,7 @@ spring:
     name: triplog
   profiles:
     active: local
+    include: mail
   config:
     import: optional:file:.env[.properties]
 

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -37,11 +37,16 @@
     <!-- 4. Root Logger 설정 -->
     <!-- 모든 환경에서 Console Appender는 항상 포함 -->
     <!-- dev 환경일 경우 File Appender도 추가 -->
-    <root level="INFO">
+    <root level="DEBUG">
         <appender-ref ref="CONSOLE"/>
-        <springProfile name="dev">
-            <appender-ref ref="FILE"/>
-        </springProfile>
     </root>
+
+    <!-- dev 환경일 때만 root logger에 FILE appender 추가 -->
+    <springProfile name="dev">
+        <root level="DEBUG">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="FILE"/>
+        </root>
+    </springProfile>
 
 </configuration>

--- a/src/test/java/com/project/triplog/TravelTrackerApplicationTests.java
+++ b/src/test/java/com/project/triplog/TravelTrackerApplicationTests.java
@@ -1,4 +1,4 @@
-package com.example.travel_tracker;
+package com.project.triplog;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -6,8 +6,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class TravelTrackerApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+    @Test
+    void contextLoads() {
+    }
 
 }

--- a/src/test/java/com/project/triplog/service/EmailVerificationServiceTest.java
+++ b/src/test/java/com/project/triplog/service/EmailVerificationServiceTest.java
@@ -1,0 +1,131 @@
+package com.project.triplog.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+
+import com.project.triplog.domain.EmailVerification;
+import com.project.triplog.dto.EmailRequest;
+import com.project.triplog.exception.EmailSendException;
+import com.project.triplog.exception.EmailVerifiedException;
+import com.project.triplog.repository.EmailVerificationRepository;
+
+class EmailVerificationServiceTest {
+	private EmailVerificationRepository emailVerificationRepository;
+	private JavaMailSender mailSender;
+	private EmailVerificationService emailVerificationService;
+
+	@BeforeEach
+	void setUp() {
+		emailVerificationRepository = mock(EmailVerificationRepository.class);
+		mailSender = mock(JavaMailSender.class);
+		emailVerificationService = new EmailVerificationService(emailVerificationRepository, mailSender);
+	}
+
+	@Test
+	@DisplayName("이메일에 대해 인증 토큰을 생성하고 저장한다")
+	void shouldGenerateAndSaveToken() {
+		String email = "test@example.com";
+
+		String token = emailVerificationService.generateToken(email);
+
+		assertThat(token).isNotBlank();
+		verify(emailVerificationRepository).save(any(EmailVerification.class));
+	}
+
+	@Test
+	@DisplayName("토큰이 유효하면 true 반환하고 인증 상태로 변경한다")
+	void shouldVerifyTokenSuccessfully() {
+		String email = "test@example.com";
+		String token = UUID.randomUUID().toString();
+		EmailVerification verification = EmailVerification.of(email, token);
+
+		when(emailVerificationRepository.findByEmail(email))
+			.thenReturn(Optional.of(verification));
+
+		boolean result = emailVerificationService.verifyToken(email, token);
+
+		assertThat(result).isTrue();
+		assertThat(verification.isVerified()).isTrue();
+	}
+
+	@Test
+	@DisplayName("이메일에 대한 인증 정보가 없으면 예외 발생")
+	void shouldThrowIfVerificationNotFound() {
+		String email = "notfound@example.com";
+		String token = UUID.randomUUID().toString();
+
+		when(emailVerificationRepository.findByEmail(email)).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> emailVerificationService.verifyToken(email, token))
+			.isInstanceOf(EmailVerifiedException.class);
+	}
+
+	@Test
+	@DisplayName("토큰이 일치하지 않으면 예외 발생")
+	void shouldThrowIfTokenMismatch() {
+		String email = "test@example.com";
+		String correctToken = UUID.randomUUID().toString();
+		String wrongToken = UUID.randomUUID().toString();
+
+		EmailVerification verification = EmailVerification.of(email, correctToken);
+		when(emailVerificationRepository.findByEmail(email)).thenReturn(Optional.of(verification));
+
+		assertThatThrownBy(() -> emailVerificationService.verifyToken(email, wrongToken))
+			.isInstanceOf(EmailVerifiedException.class);
+	}
+
+	@Test
+	@DisplayName("이메일 인증 메일을 정상적으로 발송한다")
+	void shouldSendVerificationEmailSuccessfully() {
+		EmailRequest request = new EmailRequest("test@example.com");
+
+		emailVerificationService.sendVerificationEmail(request);
+
+		verify(mailSender, times(1)).send(any(SimpleMailMessage.class));
+		verify(emailVerificationRepository, times(1)).save(any(EmailVerification.class));
+	}
+
+	@Test
+	@DisplayName("이메일 전송에 실패하면 예외 발생")
+	void shouldThrowWhenEmailSendFails() {
+		EmailRequest request = new EmailRequest("fail@example.com");
+
+		doThrow(new RuntimeException("SMTP error"))
+			.when(mailSender).send(any(SimpleMailMessage.class));
+
+		assertThatThrownBy(() -> emailVerificationService.sendVerificationEmail(request))
+			.isInstanceOf(EmailSendException.class);
+	}
+
+	@Test
+	@DisplayName("인증이 완료되지 않았거나 정보가 없으면 예외 발생")
+	void shouldThrowIfNotVerified() {
+		String email = "unverified@example.com";
+		EmailVerification verification = EmailVerification.of(email, UUID.randomUUID().toString());
+
+		when(emailVerificationRepository.findByEmail(email)).thenReturn(Optional.of(verification));
+
+		assertThatThrownBy(() -> emailVerificationService.checkVerified(email))
+			.isInstanceOf(EmailVerifiedException.class);
+	}
+
+	@Test
+	@DisplayName("이메일 인증 정보를 삭제한다")
+	void shouldDeleteVerificationSuccessfully() {
+		String email = "test@example.com";
+
+		emailVerificationService.deleteVerification(email);
+
+		verify(emailVerificationRepository).deleteByEmail(email);
+	}
+
+}

--- a/src/test/java/com/project/triplog/service/UserServiceTest.java
+++ b/src/test/java/com/project/triplog/service/UserServiceTest.java
@@ -29,23 +29,23 @@ class UserServiceTest {
 	}
 
 	@Test
-	@DisplayName("사용자명이 이미 존재하는 경우 true 반환")
-	void shouldReturnTrueWhenUsernameExists() {
-		String username = "existingUser";
-		when(userRepository.existsByUsername(username)).thenReturn(true);
+	@DisplayName("사용자 아이디가 이미 존재하는 경우 true 반환")
+	void shouldReturnTrueWhenUserIdExists() {
+		String userId = "existingUser";
+		when(userRepository.existsByUserId(userId)).thenReturn(true);
 
-		boolean result = userService.isExistUsername(username);
+		boolean result = userService.isExistUserId(userId);
 
 		assertThat(result).isTrue();
 	}
 
 	@Test
-	@DisplayName("사용자명이 존재하지 않는 경우 false 반환")
-	void shouldReturnFalseWhenUsernameDoesNotExist() {
-		String username = "newUser";
-		when(userRepository.existsByUsername(username)).thenReturn(false);
+	@DisplayName("사용자 아이디가 존재하지 않는 경우 false 반환")
+	void shouldReturnFalseWhenUserIdDoesNotExist() {
+		String userId = "newUser";
+		when(userRepository.existsByUserId(userId)).thenReturn(false);
 
-		boolean result = userService.isExistUsername(username);
+		boolean result = userService.isExistUserId(userId);
 
 		assertThat(result).isFalse();
 	}
@@ -55,7 +55,7 @@ class UserServiceTest {
 	void shouldJoinSuccessfully() {
 		JoinRequest joinRequest = new JoinRequest("newUser", "홍길동", "test@example.com", "password123");
 
-		when(userRepository.existsByUsername(anyString())).thenReturn(false);
+		when(userRepository.existsByUserId(anyString())).thenReturn(false);
 		when(userRepository.existsByEmail(anyString())).thenReturn(false);
 		when(passwordEncoder.encode(anyString())).thenReturn("encodedPassword");
 		doNothing().when(emailVerificationService).checkVerified(anyString());
@@ -67,16 +67,16 @@ class UserServiceTest {
 	}
 
 	@Test
-	@DisplayName("중복된 사용자명으로 회원가입 시 예외 발생")
-	void shouldThrowExceptionWhenUsernameExists() {
+	@DisplayName("중복된 사용자 아이디로 회원가입 시 예외 발생")
+	void shouldThrowExceptionWhenUserIdExists() {
 		JoinRequest joinRequest = new JoinRequest("existingUser", "홍길동", "test@example.com", "password123");
 
-		when(userRepository.existsByUsername(anyString())).thenReturn(true);
+		when(userRepository.existsByUserId(anyString())).thenReturn(true);
 		doNothing().when(emailVerificationService).checkVerified(anyString());
 
 		assertThatThrownBy(() -> userService.join(joinRequest))
 			.isInstanceOf(DuplicationException.class)
-			.hasMessage("이미 존재하는 사용자 이름입니다.");
+			.hasMessage("이미 존재하는 사용자 아이디입니다.");
 	}
 
 	@Test
@@ -84,7 +84,7 @@ class UserServiceTest {
 	void shouldThrowExceptionWhenEmailExists() {
 		JoinRequest joinRequest = new JoinRequest("newUser", "홍길동", "existing@example.com", "password123");
 
-		when(userRepository.existsByUsername(anyString())).thenReturn(false);
+		when(userRepository.existsByUserId(anyString())).thenReturn(false);
 		when(userRepository.existsByEmail(anyString())).thenReturn(true);
 		doNothing().when(emailVerificationService).checkVerified(anyString());
 
@@ -98,7 +98,7 @@ class UserServiceTest {
 	void shouldEncodePasswordDuringJoin() {
 		JoinRequest joinRequest = new JoinRequest("newUser", "userName", "test@example.com", "password");
 
-		when(userRepository.existsByUsername(anyString())).thenReturn(false);
+		when(userRepository.existsByUserId(anyString())).thenReturn(false);
 		when(userRepository.existsByEmail(anyString())).thenReturn(false);
 		when(passwordEncoder.encode("password")).thenReturn("encodedPassword");
 		doNothing().when(emailVerificationService).checkVerified(anyString());

--- a/src/test/java/com/project/triplog/service/UserServiceTest.java
+++ b/src/test/java/com/project/triplog/service/UserServiceTest.java
@@ -1,0 +1,123 @@
+package com.project.triplog.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import com.project.triplog.domain.User;
+import com.project.triplog.dto.JoinRequest;
+import com.project.triplog.exception.DuplicationException;
+import com.project.triplog.exception.EmailVerifiedException;
+import com.project.triplog.repository.UserRepository;
+
+class UserServiceTest {
+	private UserRepository userRepository;
+	private PasswordEncoder passwordEncoder;
+	private EmailVerificationService emailVerificationService;
+	private UserService userService;
+
+	@BeforeEach
+	void setUp() {
+		userRepository = mock(UserRepository.class);
+		passwordEncoder = mock(PasswordEncoder.class);
+		emailVerificationService = mock(EmailVerificationService.class);
+		userService = new UserService(userRepository, passwordEncoder, emailVerificationService);
+	}
+
+	@Test
+	@DisplayName("사용자명이 이미 존재하는 경우 true 반환")
+	void shouldReturnTrueWhenUsernameExists() {
+		String username = "existingUser";
+		when(userRepository.existsByUsername(username)).thenReturn(true);
+
+		boolean result = userService.isExistUsername(username);
+
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	@DisplayName("사용자명이 존재하지 않는 경우 false 반환")
+	void shouldReturnFalseWhenUsernameDoesNotExist() {
+		String username = "newUser";
+		when(userRepository.existsByUsername(username)).thenReturn(false);
+
+		boolean result = userService.isExistUsername(username);
+
+		assertThat(result).isFalse();
+	}
+
+	@Test
+	@DisplayName("정상적인 회원가입 시 저장 및 인증정보 삭제")
+	void shouldJoinSuccessfully() {
+		JoinRequest joinRequest = new JoinRequest("newUser", "홍길동", "test@example.com", "password123");
+
+		when(userRepository.existsByUsername(anyString())).thenReturn(false);
+		when(userRepository.existsByEmail(anyString())).thenReturn(false);
+		when(passwordEncoder.encode(anyString())).thenReturn("encodedPassword");
+		doNothing().when(emailVerificationService).checkVerified(anyString());
+
+		userService.join(joinRequest);
+
+		verify(userRepository, times(1)).save(any(User.class));
+		verify(emailVerificationService, times(1)).deleteVerification(joinRequest.getEmail());
+	}
+
+	@Test
+	@DisplayName("중복된 사용자명으로 회원가입 시 예외 발생")
+	void shouldThrowExceptionWhenUsernameExists() {
+		JoinRequest joinRequest = new JoinRequest("existingUser", "홍길동", "test@example.com", "password123");
+
+		when(userRepository.existsByUsername(anyString())).thenReturn(true);
+		doNothing().when(emailVerificationService).checkVerified(anyString());
+
+		assertThatThrownBy(() -> userService.join(joinRequest))
+			.isInstanceOf(DuplicationException.class)
+			.hasMessage("이미 존재하는 사용자 이름입니다.");
+	}
+
+	@Test
+	@DisplayName("중복된 이메일로 회원가입 시 예외 발생")
+	void shouldThrowExceptionWhenEmailExists() {
+		JoinRequest joinRequest = new JoinRequest("newUser", "홍길동", "existing@example.com", "password123");
+
+		when(userRepository.existsByUsername(anyString())).thenReturn(false);
+		when(userRepository.existsByEmail(anyString())).thenReturn(true);
+		doNothing().when(emailVerificationService).checkVerified(anyString());
+
+		assertThatThrownBy(() -> userService.join(joinRequest))
+			.isInstanceOf(DuplicationException.class)
+			.hasMessage("이미 존재하는 이메일입니다.");
+	}
+
+	@Test
+	@DisplayName("회원가입 시 비밀번호가 인코딩되는지 확인")
+	void shouldEncodePasswordDuringJoin() {
+		JoinRequest joinRequest = new JoinRequest("newUser", "userName", "test@example.com", "password");
+
+		when(userRepository.existsByUsername(anyString())).thenReturn(false);
+		when(userRepository.existsByEmail(anyString())).thenReturn(false);
+		when(passwordEncoder.encode("password")).thenReturn("encodedPassword");
+		doNothing().when(emailVerificationService).checkVerified(anyString());
+
+		userService.join(joinRequest);
+
+		verify(passwordEncoder, times(1)).encode("password");
+	}
+
+	@Test
+	@DisplayName("이메일 인증이 완료되지 않은 경우 예외 발생")
+	void shouldThrowExceptionWhenEmailNotVerified() {
+		JoinRequest joinRequest = new JoinRequest("newUser", "홍길동", "unverified@example.com", "password123");
+
+		doThrow(new EmailVerifiedException())
+			.when(emailVerificationService).checkVerified(joinRequest.getEmail());
+
+		assertThatThrownBy(() -> userService.join(joinRequest))
+			.isInstanceOf(EmailVerifiedException.class);
+	}
+
+}


### PR DESCRIPTION
## 구현 내용
**회원가입(이름, 아이디, 이메일, 비밀번호) API**
- 이메일 인증을 완료해야만 회원가입이 가능하도록 구현
- 아이디/이메일 중복 체크 API 제공

**이메일 인증**
- 인증 요청 시, 토큰 생성 후 메일로 인증 링크 발송
- 인증 링크 클릭 시 DB에 인증 완료 처리
- 회원가입이 완료되면 DB에 토큰 삭제
- 구글 SMTP, JavaMailSender 사용
![스크린샷 2025-06-22 오후 8 58 09](https://github.com/user-attachments/assets/2128d6ae-d7fc-4217-adcc-fe16f947aac3)


## 추후에
- 비밀번호 암호화
- 이메일 토큰 만료 기간 설정 및 재전송

## 고민
이메일 인증 - 회원 DB 저장 방식 : 인증되지 않은 유저도 유저DB에 저장해 유저 DB에 인증 컬럼을 만들고 인증 여부를 표시해야하나 고민했습니다.. 
제 생각에는 이메일 인증을 위해서는 발급된 인증 토큰을 저장할 공간이 필요했는데 그러기 위해서는 토큰 테이블을 생성하고 관리해야 했습니다. 그러면 굳이 유저 DB에 인증여부를 표시하는 것이 중복되어 저장한다고 생각이 들어서 이메일 인증이 되지 않으면 회원가입을 하지 못하도록해 유저DB에는 인증이 완료된 유저만 저장되도록 했습니다. 
이메일 인증 테이블을 생성해서 해당 테이블에 인증 여부와 토큰를 저장하였습니다. 회원가입이 완료되면 해당 테이블에 해당 이메일을 삭제하도록 했습니다. 
이렇게 구현하는 부분에 있어 문제가 없을까요? 

### 테스트 관련
1. 현재 서비스만 테스트 코드를 작성했는데 컨트롤러와 레포지토리에서 딱히 로직이 없는데 어떤 걸 테스트해야하는지 모르겠습니다..ㅠㅠ
2. 현재 작성한 단위 테스트 코드에서 테스트를 빼먹은 부분은 없는지 계속 고민이 되는데 테스트 커버리지로 판단을 하는건가요..?